### PR TITLE
"fix: 뉴스 수집 스케줄링 버그 수정" 

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -108,7 +108,7 @@ jobs:
             # 새 애플리케이션 실행
             echo "Starting new application with memory options..."
             cd $DEPLOY_DIR
-            nohup java -jar -Xms512m -Xmx512m $JAR_DEST_PATH &
+            nohup java -jar -Xms512m -Xmx512m $JAR_DEST_PATH > /dev/null 2>&1 &
             
             echo "Deployment successful!"
             

--- a/backend/src/main/java/com/newsapp/eyehope/api/config/NewsScheduler.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/config/NewsScheduler.java
@@ -15,11 +15,11 @@ public class NewsScheduler {
     
     /**
      * 10분마다 자동으로 뉴스 수집 실행
-
+     */
     @Scheduled(fixedRate = 600000) // 10분(600,000 밀리초)마다 실행
     public void scheduleNewsCollection() {
         log.info("스케줄링된 뉴스 수집 시작");
         newsService.collectAllNews();
         log.info("스케줄링된 뉴스 수집 완료");
-    }*/
+    }
 }


### PR DESCRIPTION
- 뉴스 수집 스케줄링 부분이 주석처리 되어있던 것을 수정했음
- 깃허브 액션에서 deploy 상태에서 종료가 안되는 것을 발견하여 서버 실행 명령어에 /dev/null 을 추가해서 SSH 세션이 백그라운드 프로세스와 분리되어 즉시 종료되도록 했음