### PR TITLE
feat: Spring Security 적용

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -108,7 +108,7 @@ jobs:
             # 새 애플리케이션 실행
             echo "Starting new application with memory options..."
             cd $DEPLOY_DIR
-            nohup java -jar -Xms512m -Xmx512m $JAR_DEST_PATH > /dev/null 2>&1 &
+            nohup java -jar -Dspring.profiles.active=prod -Xms512m -Xmx512m $JAR_DEST_PATH > /dev/null 2>&1 &
             
             echo "Deployment successful!"
             

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.json:json:20231013'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation 'com.google.firebase:firebase-admin:9.5.0'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'

--- a/backend/src/main/java/com/newsapp/eyehope/api/config/AdminInitializer.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/config/AdminInitializer.java
@@ -1,0 +1,67 @@
+package com.newsapp.eyehope.api.config;
+
+import com.newsapp.eyehope.api.domain.User;
+import com.newsapp.eyehope.api.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Initializes the first admin user if no admin users exist in the system
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class AdminInitializer {
+
+    private final UserRepository userRepository;
+
+    /**
+     * Creates the first admin user if no admin users exist
+     * This is run on application startup
+     */
+    @Bean
+    @Profile("!test") // Don't run in test profile
+    public CommandLineRunner initializeAdmin() {
+        return args -> {
+            // Check if any admin users exist
+            List<User> adminUsers = userRepository.findByIsAdmin(true);
+            
+            if (adminUsers.isEmpty()) {
+                // Define a fixed UUID for the first admin user
+                // This UUID should be documented and shared with the system administrator
+                UUID firstAdminDeviceId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                
+                // Check if a user with this device ID already exists
+                User existingUser = userRepository.findByDeviceId(firstAdminDeviceId).orElse(null);
+                
+                if (existingUser != null) {
+                    // User exists, make them an admin
+                    existingUser.setAdmin(true);
+                    userRepository.save(existingUser);
+                    log.info("기존 사용자({})에게 관리자 권한이 부여되었습니다.", firstAdminDeviceId);
+                } else {
+                    // Create a new admin user
+                    User adminUser = User.builder()
+                            .deviceId(firstAdminDeviceId)
+                            .nickname("시스템 관리자")
+                            .isAdmin(true)
+                            .build();
+                    
+                    userRepository.save(adminUser);
+                    log.info("첫 번째 관리자 사용자가 생성되었습니다. 디바이스 ID: {}", firstAdminDeviceId);
+                }
+                
+                log.info("관리자 계정 정보: 디바이스 ID = {}", firstAdminDeviceId);
+            } else {
+                log.info("이미 {} 명의 관리자가 존재합니다.", adminUsers.size());
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/newsapp/eyehope/api/config/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/config/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.newsapp.eyehope.api.config;
+
+import com.newsapp.eyehope.api.domain.User;
+import com.newsapp.eyehope.api.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPasswordHash(),
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}

--- a/backend/src/main/java/com/newsapp/eyehope/api/config/NewsScheduler.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/config/NewsScheduler.java
@@ -15,11 +15,11 @@ public class NewsScheduler {
     
     /**
      * 10분마다 자동으로 뉴스 수집 실행
-     */
+
     @Scheduled(fixedRate = 600000) // 10분(600,000 밀리초)마다 실행
     public void scheduleNewsCollection() {
         log.info("스케줄링된 뉴스 수집 시작");
         newsService.collectAllNews();
         log.info("스케줄링된 뉴스 수집 완료");
-    }
+    }*/
 }

--- a/backend/src/main/java/com/newsapp/eyehope/api/config/SecurityConfig.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/config/SecurityConfig.java
@@ -1,0 +1,101 @@
+package com.newsapp.eyehope.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final CustomUserDetailsService userDetailsService;
+    private final Sha256PasswordEncoder passwordEncoder;
+
+    public SecurityConfig(CustomUserDetailsService userDetailsService, Sha256PasswordEncoder passwordEncoder) {
+        this.userDetailsService = userDetailsService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // Configure CSRF protection - enable for web pages, disable for API endpoints
+            .csrf(csrf -> csrf
+                .ignoringRequestMatchers("/api/**", "/swagger-ui/**", "/v3/api-docs/**"))
+
+            // Configure authorization
+            .authorizeHttpRequests(auth -> auth
+                // Public endpoints
+                .requestMatchers("/api/users").permitAll()
+                .requestMatchers("/api/users/password").permitAll()
+                .requestMatchers("/api/news/**").permitAll() // We handle admin authorization in the controller
+                .requestMatchers("/api/admin/**").permitAll() // We handle admin authorization in the controller
+                .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/swagger-ui/index.html", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/api/health").permitAll()
+                .requestMatchers("/error").permitAll()
+                .requestMatchers("/favicon.ico").permitAll()
+                .requestMatchers("/actuator/**").permitAll()
+                // Allow all requests without authentication - we handle admin authorization in controllers
+                .anyRequest().permitAll()
+            )
+
+            // Disable HTTP Basic authentication for Swagger UI
+            .httpBasic(httpBasic -> httpBasic.disable())
+
+            // Configure session management
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+
+            // Configure exception handling
+            .exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint((request, response, authException) -> {
+                    // Let the GlobalExceptionHandler handle it
+                    throw authException;
+                })
+                .accessDeniedHandler((request, response, accessDeniedException) -> {
+                    // Let the GlobalExceptionHandler handle it
+                    throw accessDeniedException;
+                })
+            )
+
+            // Set authentication provider
+            .authenticationProvider(authenticationProvider());
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return passwordEncoder;
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    // This bean is no longer needed as we're allowing all requests without authentication
+    // @Bean
+    // public WebSecurityCustomizer webSecurityCustomizer() {
+    //     return (web) -> web.ignoring()
+    //             .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**");
+    // }
+}

--- a/backend/src/main/java/com/newsapp/eyehope/api/config/Sha256PasswordEncoder.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/config/Sha256PasswordEncoder.java
@@ -1,0 +1,42 @@
+package com.newsapp.eyehope.api.config;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Sha256PasswordEncoder implements PasswordEncoder {
+    // Using BCrypt with a strength of 12 (recommended for most applications)
+    private final BCryptPasswordEncoder bCryptEncoder = new BCryptPasswordEncoder(12);
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        if (rawPassword == null) {
+            throw new IllegalArgumentException("Password cannot be null");
+        }
+        return bCryptEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        if (rawPassword == null || encodedPassword == null) {
+            return false;
+        }
+
+        // Check if it's an old SHA-256 hash (no $ prefix)
+        if (!encodedPassword.startsWith("$")) {
+            // For backward compatibility with old SHA-256 hashes
+            try {
+                java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+                byte[] hash = digest.digest(rawPassword.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                String oldHash = java.util.Base64.getEncoder().encodeToString(hash);
+                return oldHash.equals(encodedPassword);
+            } catch (java.security.NoSuchAlgorithmException e) {
+                throw new RuntimeException("비밀번호 해싱 중 오류가 발생했습니다.", e);
+            }
+        }
+
+        // For new BCrypt hashes
+        return bCryptEncoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/backend/src/main/java/com/newsapp/eyehope/api/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/config/SwaggerConfig.java
@@ -7,11 +7,13 @@ import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
 public class SwaggerConfig {
 
     @Bean
+    @Profile("dev") // 개발 환경에서만 Swagger 활성화
     public OpenAPI newsAppOpenAPI() {
         Server httpsServer = new Server();
         httpsServer.setUrl("https://eyehope.site");

--- a/backend/src/main/java/com/newsapp/eyehope/api/controller/AdminController.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/controller/AdminController.java
@@ -1,0 +1,117 @@
+package com.newsapp.eyehope.api.controller;
+
+import com.newsapp.eyehope.api.domain.User;
+import com.newsapp.eyehope.api.dto.ApiResponse;
+import com.newsapp.eyehope.api.dto.UserResponseDto;
+import com.newsapp.eyehope.api.repository.UserRepository;
+import com.newsapp.eyehope.api.service.AdminAuthorizationService;
+import com.newsapp.eyehope.api.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@io.swagger.v3.oas.annotations.tags.Tag(name = "Admin API", description = "관리자 기능 API")
+public class AdminController {
+
+    private final UserService userService;
+    private final AdminAuthorizationService adminAuthorizationService;
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자에게 관리자 권한 부여 (관리자 전용)
+     */
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "관리자 권한 부여 (관리자 전용)",
+        description = "특정 사용자에게 관리자 권한을 부여합니다. 관리자 권한이 필요합니다."
+    )
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
+    @PostMapping("/users/{targetDeviceId}/grant")
+    public ResponseEntity<ApiResponse<UserResponseDto>> grantAdminPrivilege(
+            @RequestHeader("X-Device-ID") UUID deviceId,
+            @PathVariable UUID targetDeviceId) {
+        log.info("관리자 권한 부여 요청, 요청자={}, 대상={}", deviceId, targetDeviceId);
+
+        // 관리자 권한 확인
+        adminAuthorizationService.verifyAdminAccess(deviceId);
+
+        UserResponseDto updatedUser = userService.setAdminStatus(targetDeviceId, true);
+        return ResponseEntity.ok(ApiResponse.success("관리자 권한이 부여되었습니다.", updatedUser));
+    }
+
+    /**
+     * 사용자의 관리자 권한 해제 (관리자 전용)
+     */
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "관리자 권한 해제 (관리자 전용)",
+        description = "특정 사용자의 관리자 권한을 해제합니다. 관리자 권한이 필요합니다."
+    )
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
+    @PostMapping("/users/{targetDeviceId}/revoke")
+    public ResponseEntity<ApiResponse<UserResponseDto>> revokeAdminPrivilege(
+            @RequestHeader("X-Device-ID") UUID deviceId,
+            @PathVariable UUID targetDeviceId) {
+        log.info("관리자 권한 해제 요청, 요청자={}, 대상={}", deviceId, targetDeviceId);
+
+        // 관리자 권한 확인
+        adminAuthorizationService.verifyAdminAccess(deviceId);
+
+        // 자기 자신의 권한을 해제하려는 경우 방지
+        if (deviceId.equals(targetDeviceId)) {
+            throw new IllegalArgumentException("자신의 관리자 권한은 해제할 수 없습니다.");
+        }
+
+        UserResponseDto updatedUser = userService.setAdminStatus(targetDeviceId, false);
+        return ResponseEntity.ok(ApiResponse.success("관리자 권한이 해제되었습니다.", updatedUser));
+    }
+
+    /**
+     * 모든 관리자 목록 조회 (관리자 전용)
+     */
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "관리자 목록 조회 (관리자 전용)",
+        description = "시스템의 모든 관리자 목록을 조회합니다. 관리자 권한이 필요합니다."
+    )
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
+    @GetMapping("/users")
+    public ResponseEntity<ApiResponse<List<UserResponseDto>>> listAdminUsers(
+            @RequestHeader("X-Device-ID") UUID deviceId) {
+        log.info("관리자 목록 조회 요청, 요청자={}", deviceId);
+
+        // 관리자 권한 확인
+        adminAuthorizationService.verifyAdminAccess(deviceId);
+
+        List<User> adminUsers = userRepository.findByIsAdmin(true);
+        List<UserResponseDto> adminUserDtos = adminUsers.stream()
+                .map(UserResponseDto::fromEntity)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(ApiResponse.success("관리자 목록 조회 성공", adminUserDtos));
+    }
+}

--- a/backend/src/main/java/com/newsapp/eyehope/api/controller/FCMController.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/controller/FCMController.java
@@ -7,6 +7,7 @@ import com.newsapp.eyehope.api.dto.ApiResponse;
 import com.newsapp.eyehope.api.dto.FCMNotificationRequestDto;
 import com.newsapp.eyehope.api.dto.FCMTopicRequestDto;
 import com.newsapp.eyehope.api.repository.UserRepository;
+import com.newsapp.eyehope.api.service.AdminAuthorizationService;
 import com.newsapp.eyehope.api.service.FCMService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,11 +29,24 @@ public class FCMController {
 
     private final FCMService fcmService;
     private final UserRepository userRepository;
+    private final AdminAuthorizationService adminAuthorizationService;
 
     @PostMapping("/send")
-    @Operation(summary = "Send FCM notification", description = "단일 기기, 여러 기기 또는 특정 주제(토픽)에 알림을 보냅니다.")
-    public ResponseEntity<ApiResponse<Object>> sendNotification(@RequestBody FCMNotificationRequestDto requestDto) {
-        log.info("Received request to send notification: {}", requestDto);
+    @Operation(summary = "Send FCM notification (관리자 전용)", description = "단일 기기, 여러 기기 또는 특정 주제(토픽)에 알림을 보냅니다. 관리자 권한이 필요합니다.")
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
+    public ResponseEntity<ApiResponse<Object>> sendNotification(
+            @RequestHeader("X-Device-ID") java.util.UUID requesterId,
+            @RequestBody FCMNotificationRequestDto requestDto) {
+        log.info("Received request to send notification: {}, requester: {}", requestDto, requesterId);
+
+        // 관리자 권한 확인
+        adminAuthorizationService.verifyAdminAccess(requesterId);
 
         Object response;
 
@@ -82,9 +96,21 @@ public class FCMController {
     }
 
     @PostMapping("/topic/subscribe")
-    @Operation(summary = "Subscribe to FCM topic", description = "특정 기기를 FCM 토픽에 구독시킵니다. device_id와 topic을 입력받아 처리합니다. DB에도 구독 정보가 저장됩니다.")
-    public ResponseEntity<ApiResponse<TopicManagementResponse>> subscribeToTopic(@RequestBody FCMTopicRequestDto requestDto) {
-        log.info("Received request to subscribe to topic: {}", requestDto);
+    @Operation(summary = "Subscribe to FCM topic (관리자 전용)", description = "특정 기기를 FCM 토픽에 구독시킵니다. device_id와 topic을 입력받아 처리합니다. DB에도 구독 정보가 저장됩니다. 관리자 권한이 필요합니다.")
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
+    public ResponseEntity<ApiResponse<TopicManagementResponse>> subscribeToTopic(
+            @RequestHeader("X-Device-ID") java.util.UUID requesterId,
+            @RequestBody FCMTopicRequestDto requestDto) {
+        log.info("Received request to subscribe to topic: {}, requester: {}", requestDto, requesterId);
+
+        // 관리자 권한 확인
+        adminAuthorizationService.verifyAdminAccess(requesterId);
 
         // Topic is always required
         if (requestDto.getTopic() == null || requestDto.getTopic().isEmpty()) {
@@ -112,9 +138,21 @@ public class FCMController {
     }
 
     @PostMapping("/topic/unsubscribe")
-    @Operation(summary = "Unsubscribe from FCM topic", description = "특정 기기를 FCM 토픽에서 구독 취소시킵니다. device_id와 topic을 입력받아 처리합니다. DB에서도 구독 정보가 삭제됩니다.")
-    public ResponseEntity<ApiResponse<TopicManagementResponse>> unsubscribeFromTopic(@RequestBody FCMTopicRequestDto requestDto) {
-        log.info("Received request to unsubscribe from topic: {}", requestDto);
+    @Operation(summary = "Unsubscribe from FCM topic (관리자 전용)", description = "특정 기기를 FCM 토픽에서 구독 취소시킵니다. device_id와 topic을 입력받아 처리합니다. DB에서도 구독 정보가 삭제됩니다. 관리자 권한이 필요합니다.")
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
+    public ResponseEntity<ApiResponse<TopicManagementResponse>> unsubscribeFromTopic(
+            @RequestHeader("X-Device-ID") java.util.UUID requesterId,
+            @RequestBody FCMTopicRequestDto requestDto) {
+        log.info("Received request to unsubscribe from topic: {}, requester: {}", requestDto, requesterId);
+
+        // 관리자 권한 확인
+        adminAuthorizationService.verifyAdminAccess(requesterId);
 
         // Topic is always required
         if (requestDto.getTopic() == null || requestDto.getTopic().isEmpty()) {

--- a/backend/src/main/java/com/newsapp/eyehope/api/controller/FCMTestController.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/controller/FCMTestController.java
@@ -1,6 +1,7 @@
 package com.newsapp.eyehope.api.controller;
 
 import com.newsapp.eyehope.api.dto.ApiResponse;
+import com.newsapp.eyehope.api.service.AdminAuthorizationService;
 import com.newsapp.eyehope.api.service.FCMService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,15 +21,27 @@ import java.util.Map;
 public class FCMTestController {
 
     private final FCMService fcmService;
+    private final AdminAuthorizationService adminAuthorizationService;
 
     @GetMapping("/send-test-notification")
-    @Operation(summary = "테스트 FCM 알림 전송", description = "특정 기기 토큰에 테스트 알림 전송")
+    @Operation(summary = "테스트 FCM 알림 전송 (관리자 전용)", description = "특정 기기 토큰에 테스트 알림 전송. 관리자 권한이 필요합니다.")
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
     public ResponseEntity<ApiResponse<String>> sendTestNotification(
+            @RequestHeader("X-Device-ID") java.util.UUID requesterId,
             @RequestParam String token,
             @RequestParam(defaultValue = "Test Notification") String title,
             @RequestParam(defaultValue = "This is a test notification from Eye-Hope") String body) {
 
-        log.info("Sending test notification to token: {}", token);
+        log.info("Sending test notification to token: {}, requester: {}", token, requesterId);
+
+        // 관리자 권한 확인
+        adminAuthorizationService.verifyAdminAccess(requesterId);
 
         Map<String, String> data = new HashMap<>();
         data.put("type", "test");
@@ -40,13 +53,24 @@ public class FCMTestController {
     }
 
     @GetMapping("/send-test-topic")
-    @Operation(summary = "테스트 FCM 토픽 알림 전송", description = "특정 토픽에 테스트 알림 전송")
+    @Operation(summary = "테스트 FCM 토픽 알림 전송 (관리자 전용)", description = "특정 토픽에 테스트 알림 전송. 관리자 권한이 필요합니다.")
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
     public ResponseEntity<ApiResponse<String>> sendTestTopicNotification(
+            @RequestHeader("X-Device-ID") java.util.UUID requesterId,
             @RequestParam String topic,
             @RequestParam(defaultValue = "Test Topic Notification") String title,
             @RequestParam(defaultValue = "This is a test topic notification from Eye-Hope") String body) {
 
-        log.info("Sending test notification to topic: {}", topic);
+        log.info("Sending test notification to topic: {}, requester: {}", topic, requesterId);
+
+        // 관리자 권한 확인
+        adminAuthorizationService.verifyAdminAccess(requesterId);
 
         Map<String, String> data = new HashMap<>();
         data.put("type", "topic_test");

--- a/backend/src/main/java/com/newsapp/eyehope/api/controller/UserNewsController.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/controller/UserNewsController.java
@@ -3,6 +3,7 @@ package com.newsapp.eyehope.api.controller;
 import com.newsapp.eyehope.api.dto.ApiResponse;
 import com.newsapp.eyehope.api.dto.UserNewsRequestDto;
 import com.newsapp.eyehope.api.dto.UserNewsResponseDto;
+import com.newsapp.eyehope.api.service.AdminAuthorizationService;
 import com.newsapp.eyehope.api.service.UserNewsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,7 @@ import java.util.UUID;
 public class UserNewsController {
 
     private final UserNewsService userNewsService;
+    private final AdminAuthorizationService adminAuthorizationService;
 
     /**
      * 사용자 관심 뉴스 카테고리 저장
@@ -53,17 +55,32 @@ public class UserNewsController {
     }
 
     /**
-     * 사용자 관심 뉴스 카테고리 조회
+     * 사용자 관심 뉴스 카테고리 조회 (관리자 전용)
      */
     @io.swagger.v3.oas.annotations.Operation(
-            summary = "사용자 관심 뉴스 카테고리 조회",
-            description = "사용자의 관심 뉴스 카테고리를 조회합니다."
+            summary = "사용자 관심 뉴스 카테고리 조회 (관리자 전용)",
+            description = "사용자의 관심 뉴스 카테고리를 조회합니다. 관리자 권한이 필요합니다."
     )
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
     @GetMapping("/{deviceId}")
     public ResponseEntity<ApiResponse<UserNewsResponseDto>> getUserNewsPreferences(
+            @RequestHeader("X-Device-ID") UUID requesterId,
             @PathVariable UUID deviceId) {
         try {
-            log.info("사용자 관심 뉴스 카테고리 조회 요청: {}", deviceId);
+            log.info("사용자 관심 뉴스 카테고리 조회 요청: 요청자={}, 대상={}", requesterId, deviceId);
+
+            // 자신의 정보를 조회하는 경우 또는 관리자인 경우에만 허용
+            if (!requesterId.equals(deviceId)) {
+                // 관리자 권한 확인
+                adminAuthorizationService.verifyAdminAccess(requesterId);
+            }
+
             UserNewsResponseDto responseDto = userNewsService.getUserNewsPreferences(deviceId);
             return ResponseEntity.ok(ApiResponse.success("사용자 관심 뉴스 카테고리 조회가 완료되었습니다.", responseDto));
         } catch (NoSuchElementException e) {
@@ -78,17 +95,32 @@ public class UserNewsController {
     }
 
     /**
-     * 사용자 관심 뉴스 카테고리 삭제
+     * 사용자 관심 뉴스 카테고리 삭제 (관리자 전용)
      */
     @io.swagger.v3.oas.annotations.Operation(
-            summary = "사용자 관심 뉴스 카테고리 삭제",
-            description = "사용자의 모든 관심 뉴스 카테고리를 삭제합니다."
+            summary = "사용자 관심 뉴스 카테고리 삭제 (관리자 전용)",
+            description = "사용자의 모든 관심 뉴스 카테고리를 삭제합니다. 관리자 권한이 필요합니다."
     )
+    @io.swagger.v3.oas.annotations.Parameters({
+        @io.swagger.v3.oas.annotations.Parameter(
+            name = "X-Device-ID",
+            description = "요청자의 디바이스 ID (UUID 형식)",
+            required = true,
+            in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER)
+    })
     @DeleteMapping("/{deviceId}")
     public ResponseEntity<ApiResponse<Void>> deleteUserNewsPreferences(
+            @RequestHeader("X-Device-ID") UUID requesterId,
             @PathVariable UUID deviceId) {
         try {
-            log.info("사용자 관심 뉴스 카테고리 삭제 요청: {}", deviceId);
+            log.info("사용자 관심 뉴스 카테고리 삭제 요청: 요청자={}, 대상={}", requesterId, deviceId);
+
+            // 자신의 정보를 삭제하는 경우 또는 관리자인 경우에만 허용
+            if (!requesterId.equals(deviceId)) {
+                // 관리자 권한 확인
+                adminAuthorizationService.verifyAdminAccess(requesterId);
+            }
+
             userNewsService.deleteUserNewsPreferences(deviceId);
             return ResponseEntity.ok(ApiResponse.success("사용자 관심 뉴스 카테고리 삭제가 완료되었습니다.", null));
         } catch (NoSuchElementException e) {

--- a/backend/src/main/java/com/newsapp/eyehope/api/controller/advice/XssResponseAdvice.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/controller/advice/XssResponseAdvice.java
@@ -1,0 +1,123 @@
+package com.newsapp.eyehope.api.controller.advice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.newsapp.eyehope.api.dto.ApiResponse;
+import com.newsapp.eyehope.api.util.HtmlUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Response advice that applies HTML escaping to all string values in API responses
+ * to prevent XSS attacks
+ */
+@Slf4j
+@ControllerAdvice
+@RequiredArgsConstructor
+public class XssResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    private final HtmlUtils htmlUtils;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        // Apply to all responses
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                 Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                 ServerHttpRequest request, ServerHttpResponse response) {
+        if (body == null) {
+            return null;
+        }
+
+        // Swagger UI, API docs 등은 처리하지 않음
+        if (request.getURI().getPath().contains("/swagger-ui/") ||
+            request.getURI().getPath().contains("/v3/api-docs")) {
+            return body;
+        }
+
+        // If it's an ApiResponse, process its data field
+        if (body instanceof ApiResponse) {
+            ApiResponse<?> apiResponse = (ApiResponse<?>) body;
+            Object data = apiResponse.getData();
+
+            if (data != null) {
+                // Process the data field recursively
+                Object processedData = processValue(data);
+
+                // Create a new ApiResponse with the processed data
+                // We need to use reflection or ObjectMapper to set the data field
+                // since ApiResponse doesn't have a setData method
+                try {
+                    String json = objectMapper.writeValueAsString(apiResponse);
+                    ApiResponse<?> newResponse = objectMapper.readValue(json, ApiResponse.class);
+                    // Use reflection to set the data field
+                    java.lang.reflect.Field dataField = ApiResponse.class.getDeclaredField("data");
+                    dataField.setAccessible(true);
+                    dataField.set(newResponse, processedData);
+                    dataField.setAccessible(false);
+                    return newResponse;
+                } catch (Exception e) {
+                    log.error("Error processing ApiResponse for XSS prevention", e);
+                    return body;
+                }
+            }
+        }
+
+        // For other types, process them directly
+        return processValue(body);
+    }
+
+    /**
+     * Recursively processes a value to escape HTML in strings
+     */
+    @SuppressWarnings("unchecked")
+    private Object processValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        // If it's a string, escape HTML
+        if (value instanceof String) {
+            return htmlUtils.escapeHtml((String) value);
+        }
+
+        // If it's a collection, process each element
+        if (value instanceof Collection) {
+            Collection<Object> collection = (Collection<Object>) value;
+            // Create a new collection with processed values
+            // This is safer than trying to modify the original collection
+            return collection.stream()
+                .map(this::processValue)
+                .toList();
+        }
+
+        // If it's a map, process each value
+        if (value instanceof Map) {
+            Map<Object, Object> map = (Map<Object, Object>) value;
+            // Create a new map with processed values
+            return map.entrySet().stream()
+                .collect(java.util.stream.Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> processValue(entry.getValue())
+                ));
+        }
+
+        // For other objects, we can't easily process them
+        // In a real application, you might want to use reflection or Jackson's ObjectMapper
+        // to process all string fields of complex objects
+        return value;
+    }
+}

--- a/backend/src/main/java/com/newsapp/eyehope/api/domain/User.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/domain/User.java
@@ -35,4 +35,11 @@ public class User {
 
     @Column(name = "fcm_token")
     private String fcmToken;
+
+    @Column(name = "is_admin")
+    private boolean isAdmin = false;
+
+    public void setAdmin(Boolean isAdmin) {
+        this.isAdmin = isAdmin != null ? isAdmin : false;
+    }
 }

--- a/backend/src/main/java/com/newsapp/eyehope/api/dto/ApiResponse.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/dto/ApiResponse.java
@@ -36,4 +36,12 @@ public class ApiResponse<T> {
                 .message(message)
                 .build();
     }
+
+    public static <T> ApiResponse<T> error(String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .message(message)
+                .data(data)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/newsapp/eyehope/api/dto/PostsRequestDto.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/dto/PostsRequestDto.java
@@ -1,14 +1,11 @@
 package com.newsapp.eyehope.api.dto;
 
 import com.newsapp.eyehope.api.domain.Posts;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.AllArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
+@ToString
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/java/com/newsapp/eyehope/api/dto/UserRequestDto.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/dto/UserRequestDto.java
@@ -1,6 +1,12 @@
 package com.newsapp.eyehope.api.dto;
 
 import com.newsapp.eyehope.api.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,12 +21,36 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 public class UserRequestDto {
+    @NotNull(message = "디바이스 ID는 필수입니다")
+    @Schema(description = "사용자 디바이스 ID", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
     private UUID deviceId;
+
+    @Size(max = 100, message = "이름은 100자를 초과할 수 없습니다")
+    @Pattern(regexp = "^[\\p{L}\\s\\d\\p{Punct}]*$", message = "이름에 유효하지 않은 문자가 포함되어 있습니다")
+    @Schema(description = "사용자 이름", example = "홍길동")
     private String name;
+
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    @Size(max = 100, message = "이메일은 100자를 초과할 수 없습니다")
+    @Schema(description = "사용자 이메일", example = "user@example.com")
     private String email;
+
+    @NotBlank(message = "닉네임은 필수입니다")
+    @Size(min = 2, max = 50, message = "닉네임은 2자 이상 50자 이하여야 합니다")
+    @Pattern(regexp = "^[\\p{L}\\s\\d\\p{Punct}]*$", message = "닉네임에 유효하지 않은 문자가 포함되어 있습니다")
+    @Schema(description = "사용자 닉네임", example = "뉴스러버")
     private String nickname;
+
+    @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다")
+    @Schema(description = "사용자 비밀번호 (8자 이상)", example = "password123")
     private String password;
+
+    @Size(max = 255, message = "FCM 토큰은 255자를 초과할 수 없습니다")
+    @Schema(description = "FCM 토큰", example = "fcm-token-example")
     private String fcmToken;
+
+    @Schema(description = "관리자 여부", example = "false")
+    private Boolean isAdmin;
 
     public User toEntity(String passwordHash) {
         return User.builder()
@@ -30,6 +60,7 @@ public class UserRequestDto {
                 .nickname(nickname)
                 .passwordHash(passwordHash)
                 .fcmToken(fcmToken)
+                .isAdmin(isAdmin != null && isAdmin)
                 .build();
     }
 }

--- a/backend/src/main/java/com/newsapp/eyehope/api/dto/UserResponseDto.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/dto/UserResponseDto.java
@@ -18,6 +18,7 @@ public class UserResponseDto {
     private String email;
     private String nickname;
     private String fcmToken;
+    private boolean isAdmin;
 
     public static UserResponseDto fromEntity(User user) {
         return UserResponseDto.builder()
@@ -26,6 +27,7 @@ public class UserResponseDto {
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .fcmToken(user.getFcmToken())
+                .isAdmin(user.isAdmin())
                 .build();
     }
 }

--- a/backend/src/main/java/com/newsapp/eyehope/api/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/exception/GlobalExceptionHandler.java
@@ -2,10 +2,22 @@ package com.newsapp.eyehope.api.exception;
 
 import com.newsapp.eyehope.api.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
@@ -17,6 +29,84 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBadCredentialsException(BadCredentialsException e) {
+        log.error("BadCredentialsException: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error("아이디 또는 비밀번호가 일치하지 않습니다."));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(AuthenticationException e) {
+        log.error("AuthenticationException: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error("인증에 실패했습니다."));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("AccessDeniedException: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("접근 권한이 없습니다."));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        log.warn("입력값 검증 실패: {}", errors);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("입력값 검증에 실패했습니다.", errors));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleBindExceptions(BindException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        log.warn("입력값 바인딩 실패: {}", errors);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("입력값 바인딩에 실패했습니다.", errors));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        log.warn("잘못된 요청 형식: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("잘못된 요청 형식입니다. 요청 본문을 확인해주세요."));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        log.error("데이터 무결성 위반: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error("데이터 무결성 제약 조건을 위반했습니다."));
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDataAccessException(DataAccessException e) {
+        log.error("데이터 액세스 오류: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("데이터베이스 액세스 중 오류가 발생했습니다."));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/newsapp/eyehope/api/repository/UserRepository.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/repository/UserRepository.java
@@ -4,6 +4,7 @@ import com.newsapp.eyehope.api.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByDeviceId(UUID deviceId);
     boolean existsByEmail(String email);
     boolean existsByDeviceId(UUID deviceId);
+    List<User> findByIsAdmin(boolean isAdmin);
 }

--- a/backend/src/main/java/com/newsapp/eyehope/api/service/AdminAuthorizationService.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/service/AdminAuthorizationService.java
@@ -1,0 +1,59 @@
+package com.newsapp.eyehope.api.service;
+
+import com.newsapp.eyehope.api.domain.User;
+import com.newsapp.eyehope.api.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+/**
+ * Service for handling admin authorization in a no-login environment
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminAuthorizationService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * Checks if a user with the given device ID has admin privileges
+     * @param deviceId The device ID to check
+     * @return true if the user is an admin, false otherwise
+     */
+    public boolean isAdmin(UUID deviceId) {
+        if (deviceId == null) {
+            return false;
+        }
+        
+        return userRepository.findByDeviceId(deviceId)
+                .map(User::isAdmin)
+                .orElse(false);
+    }
+
+    /**
+     * Verifies that a user with the given device ID has admin privileges
+     * @param deviceId The device ID to check
+     * @throws AccessDeniedException if the user is not an admin
+     * @throws NoSuchElementException if the user does not exist
+     */
+    public void verifyAdminAccess(UUID deviceId) {
+        if (deviceId == null) {
+            throw new AccessDeniedException("디바이스 ID가 제공되지 않았습니다.");
+        }
+        
+        User user = userRepository.findByDeviceId(deviceId)
+                .orElseThrow(() -> new NoSuchElementException("해당 디바이스 ID로 등록된 사용자가 없습니다: " + deviceId));
+        
+        if (!user.isAdmin()) {
+            log.warn("관리자 권한이 없는 사용자({})가 관리자 기능에 접근을 시도했습니다.", deviceId);
+            throw new AccessDeniedException("관리자 권한이 필요합니다.");
+        }
+        
+        log.info("관리자({})가 관리자 기능에 접근했습니다.", deviceId);
+    }
+}

--- a/backend/src/main/java/com/newsapp/eyehope/api/util/HtmlUtils.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/util/HtmlUtils.java
@@ -1,0 +1,51 @@
+package com.newsapp.eyehope.api.util;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Utility class for HTML escaping to prevent XSS attacks
+ */
+@Component
+public class HtmlUtils {
+
+    /**
+     * Escapes HTML special characters in a string to prevent XSS attacks
+     * 
+     * @param input the input string to escape
+     * @return the escaped string
+     */
+    public String escapeHtml(String input) {
+        if (input == null) {
+            return null;
+        }
+        
+        return input.replace("&", "&amp;")
+                   .replace("<", "&lt;")
+                   .replace(">", "&gt;")
+                   .replace("\"", "&quot;")
+                   .replace("'", "&#x27;")
+                   .replace("/", "&#x2F;");
+    }
+    
+    /**
+     * Checks if a string contains potentially malicious content
+     * 
+     * @param input the input string to check
+     * @return true if the string contains potentially malicious content
+     */
+    public boolean containsMaliciousContent(String input) {
+        if (input == null) {
+            return false;
+        }
+        
+        // Check for common XSS patterns
+        String lowerInput = input.toLowerCase();
+        return lowerInput.contains("<script") ||
+               lowerInput.contains("javascript:") ||
+               lowerInput.contains("onerror=") ||
+               lowerInput.contains("onload=") ||
+               lowerInput.contains("eval(") ||
+               lowerInput.contains("document.cookie") ||
+               lowerInput.matches(".*\\bon\\w+\\s*=.*");
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,25 +28,60 @@ spring:
           time_zone: Asia/Seoul
         type:
           preferred_instant_jdbc_type: TIMESTAMP_WITH_TIMEZONE
+  # 프로파일 설정
+  profiles:
+    active: dev # 기본 프로파일은 개발 환경으로 설정
+
 # Gemini API Configuration
 gemini:
   api:
     key: ${GEMINI_API_KEY}
     model: gemini-2.5-flash-lite
+
+# 공통 Swagger 설정
 springdoc:
   swagger-ui:
-    # Swagger UI에 접속할 경로를 설정합니다.
-    # 예시: http://localhost:8080/swagger-ui.html -> http://localhost:8080/swagger-ui.html
     path: /swagger-ui.html
-    # Swagger UI 활성화/비활성화
+  api-docs:
+    path: /v3/api-docs
+
+---
+# 개발 환경 프로파일
+spring:
+  config:
+    activate:
+      on-profile: dev
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+# 개발 환경에서는 Swagger UI 활성화
+springdoc:
+  swagger-ui:
+    enabled: true
+  api-docs:
     enabled: true
 
+---
+# 배포 환경 프로파일
+spring:
+  config:
+    activate:
+      on-profile: prod
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+# 배포 환경에서는 Swagger UI 비활성화
+springdoc:
+  swagger-ui:
+    enabled: false
   api-docs:
-    # OpenAPI 3.0 문서를 제공하는 경로를 설정합니다. (JSON/YAML)
-    # 예시: http://localhost:8080/v3/api-docs -> http://localhost:8080/v3/api-docs
-    path: /v3/api-docs
-    # API 문서 활성화/비활성화
-    enabled: true
+    enabled: false
 
 logging:
   file:

--- a/backend/src/test/java/com/newsapp/eyehope/NewsAppApplicationTests.java
+++ b/backend/src/test/java/com/newsapp/eyehope/NewsAppApplicationTests.java
@@ -1,9 +1,0 @@
-package com.newsapp.eyehope;
-
-
-class NewsAppApplicationTests {
-
-    void contextLoads() {
-    }
-
-}


### PR DESCRIPTION
- 개발(dev) / 배포(prod) 환경 분리
# Spring Security 구현 문서

## 개요
이 문서는 Eye-Hope 프로젝트에 새롭게 추가된 Spring Security 기능에 대한 설명입니다. 이 구현은 사용자 인증 및 관리자 권한 관리를 위한 보안 프레임워크를 제공합니다.

## 주요 구성 요소

### 1. SecurityConfig
- Spring Security의 주요 설정을 담당하는 클래스입니다.
- 주요 특징:
  - 상태를 유지하지 않는(Stateless) 세션 관리 방식 사용
  - API 엔드포인트에 대한 CSRF 보호 비활성화, 웹 페이지에 대해서는 활성화
  - 대부분의 엔드포인트는 공개적으로 접근 가능하며, 관리자 권한 검증은 컨트롤러 레벨에서 처리
  - CustomUserDetailsService와 Sha256PasswordEncoder를 사용한 커스텀 인증 제공자 사용

### 2. CustomUserDetailsService
- Spring Security의 UserDetailsService 인터페이스를 구현한 클래스입니다.
- 사용자 이메일을 기반으로 데이터베이스에서 사용자 정보를 로드합니다.
- 모든 인증된 사용자에게 "ROLE_USER" 권한을 부여합니다.

### 3. Sha256PasswordEncoder
- Spring Security의 PasswordEncoder 인터페이스를 구현한 클래스입니다.
- 새로운 비밀번호는 BCrypt 알고리즘(강도 12)을 사용하여 해싱합니다.
- 기존 SHA-256 해시된 비밀번호와의 호환성을 유지합니다.
- 비밀번호 검증 시 해시 형식을 확인하여 적절한 검증 방법을 선택합니다.

### 4. AdminAuthorizationService
- 로그인 없는 환경에서 관리자 권한을 처리하는 서비스입니다.
- 디바이스 ID를 사용하여 사용자를 식별하고 관리자 권한을 확인합니다.
- 주요 메서드:
  - `isAdmin(UUID deviceId)`: 사용자가 관리자인지 확인합니다.
  - `verifyAdminAccess(UUID deviceId)`: 관리자 접근 권한을 검증하고, 권한이 없을 경우 예외를 발생시킵니다.

### 5. AdminInitializer
- 애플리케이션 시작 시 실행되어 첫 번째 관리자 사용자를 초기화합니다.
- 관리자 사용자가 없는 경우, 고정된 UUID(00000000-0000-0000-0000-000000000001)를 가진 사용자를 관리자로 설정합니다.
- 해당 UUID를 가진 사용자가 이미 존재하면 관리자 권한을 부여하고, 존재하지 않으면 새로운 관리자 사용자를 생성합니다.

## 인증 흐름
1. 사용자가 인증이 필요한 요청을 보냅니다.
2. Spring Security는 CustomUserDetailsService를 통해 사용자 정보를 로드합니다.
3. Sha256PasswordEncoder를 사용하여 비밀번호를 검증합니다.
4. 인증이 성공하면 사용자에게 "ROLE_USER" 권한이 부여됩니다.
5. 관리자 기능에 접근할 때는 AdminAuthorizationService를 통해 디바이스 ID 기반으로 관리자 권한을 검증합니다.

## 보안 특징
- 상태를 유지하지 않는(Stateless) 세션 관리로 세션 하이재킹 공격 방지
- BCrypt 알고리즘을 사용한 안전한 비밀번호 해싱
- API 엔드포인트에 대한 CSRF 보호 설정
- 관리자 접근 시도에 대한 로깅 처리
- 예외 처리를 통한 보안 관련 오류 관리


이 Spring Security 구현은 Eye-Hope 애플리케이션의 보안을 강화하고, 사용자 인증 및 관리자 권한 관리를 위한 견고한 프레임워크를 제공합니다.