### PR TITLE
feat: 뉴스 요약 알고리즘 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.json:json:20231013'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation 'com.google.firebase:firebase-admin:9.5.0'
+    implementation 'org.jsoup:jsoup:1.17.2'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'


### PR DESCRIPTION
- 기존에는 Gemini API 프롬프트에 뉴스 URL을 전달하고 내용을 요약하도록 시켰음
- Gemini API가 URL 정보를 제대로 불러오지 못하고, 뉴스의 제목만 가지고 내용을 임의로 만들어냈음(할루시네이션)
- 따라서 뉴스의 본문을 프롬프트에 전달하도록 변경하여 문제를 해결함

- Jsoup 라이브러리로 뉴스 본문을 추출하도록 변경