### PR TITLE
feat: 뉴스 요약 API를 Local LLM에서 OpenRouter로 변경

### DIFF
--- a/backend/src/main/java/com/newsapp/eyehope/api/config/OpenRouterConfig.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/config/OpenRouterConfig.java
@@ -1,0 +1,29 @@
+package com.newsapp.eyehope.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenRouterConfig {
+
+    @Value("${openrouter.api.key}")
+    private String apiKey;
+
+    @Value("${openrouter.api.model}")
+    private String model;
+
+    private static final String OPENROUTER_API_URL =
+            "https://openrouter.ai/api/v1/chat/completions";
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public String getApiUrl() {
+        return OPENROUTER_API_URL;
+    }
+}

--- a/backend/src/main/java/com/newsapp/eyehope/api/service/NewsService.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/service/NewsService.java
@@ -28,7 +28,7 @@ public class NewsService {
     private final RssFeedService rssFeedService;
     private final PostsRepository postsRepository;
     private final GeminiService geminiService;
-    private final LocalLlmService localLlmService;
+    private final OpenRouterService openRouterService;
 
     // 전체 수집
     @Transactional
@@ -80,7 +80,7 @@ public class NewsService {
                 }
 
                 try {
-                    // URL을 사용하여 Gemini API로 내용 요약
+                    // URL을 사용하여 OpenRouter API로 내용 요약
                     String summarizedContent = summarizeNewsContent(dto.getUrl(), dto.getTitle());
 
                     // 요약된 내용이 있으면 DTO의 content 필드 업데이트
@@ -160,7 +160,7 @@ public class NewsService {
     }
 
     /**
-     * Gemini API를 사용하여 뉴스 URL의 내용을 요약
+     * OpenRouter API를 사용하여 뉴스 URL의 내용을 요약
      * @param url 뉴스 기사 URL
      * @param title 뉴스 제목
      * @return 요약된 내용
@@ -193,7 +193,7 @@ public class NewsService {
             title, newsContent
         );
 
-        return localLlmService.generateContent(prompt);
+        return openRouterService.generateContent(prompt);
     }
 
 

--- a/backend/src/main/java/com/newsapp/eyehope/api/service/OpenRouterService.java
+++ b/backend/src/main/java/com/newsapp/eyehope/api/service/OpenRouterService.java
@@ -1,0 +1,100 @@
+package com.newsapp.eyehope.api.service;
+
+import com.newsapp.eyehope.api.config.OpenRouterConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+public class OpenRouterService {
+
+    private static final int TIMEOUT_MS = 120_000; // 2분
+
+    private final OpenRouterConfig openRouterConfig;
+    private final RestTemplate restTemplate;
+
+    public OpenRouterService(OpenRouterConfig openRouterConfig) {
+        this.openRouterConfig = openRouterConfig;
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(TIMEOUT_MS);
+        factory.setReadTimeout(TIMEOUT_MS);
+        this.restTemplate = new RestTemplate(factory);
+    }
+
+    /**
+     * OpenRouter API를 사용하여 콘텐츠 생성
+     * @param prompt 프롬프트
+     * @return 생성된 콘텐츠
+     */
+    public String generateContent(String prompt) {
+        try {
+            // OpenAI 호환 API 요청 형식 구성
+            JSONObject requestBody = new JSONObject();
+
+            JSONArray messages = new JSONArray();
+            JSONObject userMessage = new JSONObject();
+            userMessage.put("role", "user");
+            userMessage.put("content", prompt);
+            messages.put(userMessage);
+
+            requestBody.put("model", openRouterConfig.getModel());
+            requestBody.put("messages", messages);
+            requestBody.put("temperature", 0.7);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(openRouterConfig.getApiKey());
+            // OpenRouter 권장 헤더 (리더보드/통계 집계용)
+            headers.set("HTTP-Referer", "https://eye-hope.com");
+            headers.set("X-Title", "Eye-Hope");
+
+            HttpEntity<String> entity = new HttpEntity<>(requestBody.toString(), headers);
+
+            String response = restTemplate.postForObject(openRouterConfig.getApiUrl(), entity, String.class);
+
+            if (response == null) {
+                return "Error: OpenRouter로부터 응답을 받지 못했습니다.";
+            }
+
+            return extractTextFromResponse(response);
+        } catch (RestClientException e) {
+            log.error("OpenRouter 호출 중 오류 발생: {}", e.getMessage(), e);
+            return "Error generating content: " + e.getMessage();
+        } catch (Exception e) {
+            log.error("OpenRouter 호출 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            return "Error generating content: " + e.getMessage();
+        }
+    }
+
+    /**
+     * OpenAI 호환 API 응답에서 텍스트 추출
+     * @param response JSON 응답
+     * @return 추출된 텍스트
+     */
+    private String extractTextFromResponse(String response) {
+        try {
+            JSONObject jsonResponse = new JSONObject(response);
+            JSONArray choices = jsonResponse.getJSONArray("choices");
+
+            if (choices.length() > 0) {
+                JSONObject choice = choices.getJSONObject(0);
+                JSONObject message = choice.getJSONObject("message");
+                return message.getString("content");
+            }
+
+            return "No response generated";
+        } catch (Exception e) {
+            log.error("OpenRouter 응답 파싱 중 오류 발생: {}", e.getMessage(), e);
+            return "Error parsing response: " + e.getMessage();
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -38,6 +38,12 @@ gemini:
     key: ${GEMINI_API_KEY}
     model: gemini-2.5-flash-lite
 
+# OpenRouter API Configuration
+openrouter:
+  api:
+    key: ${OPENROUTER_API_KEY}
+    model: openai/gpt-oss-120b:free
+
 # 공통 Swagger 설정
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## Summary
- 뉴스 요약 LLM을 Local LLM(llama-server)에서 OpenRouter 게이트웨이로 전환
- 기본 모델은 `openai/gpt-oss-120b:free` (무료 티어)
- `LocalLlmService`, `GeminiService`, `GeminiConfig`는 롤백을 위해 코드베이스에 보존 (호출만 끊음)

## Why
- 로컬 LLM은 배포 환경에서 별도 추론 서버(`:8888`)를 띄워야 해서 운영 부담이 큼
- OpenRouter는 OpenAI 호환 API로 다양한 모델을 단일 엔드포인트에서 제공 → 기존 `LocalLlmService` 요청/응답 구조를 거의 그대로 재사용 가능
- 무료 모델 선택으로 비용 없이 전환 가능

## Changes
- `backend/src/main/java/com/newsapp/eyehope/api/config/OpenRouterConfig.java` (신규)
  - `@Value`로 `openrouter.api.key`, `openrouter.api.model` 주입
  - 엔드포인트 URL: `https://openrouter.ai/api/v1/chat/completions`
- `backend/src/main/java/com/newsapp/eyehope/api/service/OpenRouterService.java` (신규)
  - `RestTemplate` + `SimpleClientHttpRequestFactory` (connect/read timeout 120s)
  - `Authorization: Bearer <API_KEY>`, `HTTP-Referer`, `X-Title` 헤더 포함
  - 응답 파싱: `choices[0].message.content` (OpenAI 호환)
  - `NewsService.savePosts`의 실패 판정 규약(`startsWith("Error")`)과 호환되는 에러 메시지 형식 유지
- `backend/src/main/java/com/newsapp/eyehope/api/service/NewsService.java`
  - `LocalLlmService` 주입 → `OpenRouterService` 교체 (L31, L196)
  - 주석 정확화 (L83, L163)
- `backend/src/main/resources/application.yml`
  - `openrouter.api.key` / `openrouter.api.model` 블록 추가

## Deployment Notes
- **신규 환경변수 `OPENROUTER_API_KEY` 필요** — CI/CD 및 운영 서버 모두 설정 필요
- OpenRouter dashboard (https://openrouter.ai/keys)에서 API 키 발급
- `GEMINI_API_KEY`는 `GeminiService`/`GeminiConfig`가 남아있어 계속 필요 (제거 시 기동 실패)
- 로컬 LLM 서버는 더 이상 기동 불필요

## Rollback
- `NewsService.java`의 `openRouterService` → `localLlmService` 한 줄 교체로 즉시 롤백 가능 (`LocalLlmService` 보존됨)

## Test plan
- [ ] `OPENROUTER_API_KEY` 환경변수 설정 후 `./gradlew bootRun` 기동 확인
- [ ] `NewsScheduler`의 `@Scheduled` 실행 또는 수동 트리거로 뉴스 수집 동작 확인
- [ ] 로그에서 `뉴스 요약 성공: {제목}` 메시지 및 DB `posts.content`에 한국어 3~4문장 요약 저장 확인
- [ ] CI/CD workflow에 `OPENROUTER_API_KEY` 시크릿 추가 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)